### PR TITLE
Add TestParseUntilEOFConformsToParse

### DIFF
--- a/parse_internal_test.go
+++ b/parse_internal_test.go
@@ -24,26 +24,14 @@ func TestParseUntilEOFConformsToParse(t *testing.T) {
 			t.Run(f.Name(), func(t *testing.T) {
 				t.Parallel()
 				// Read dataset with ParseUntilEOF
-				dcm, err := os.Open("./testdata/" + f.Name())
-				if err != nil {
-					t.Errorf("Unable to open %s. Error: %v", f.Name(), err)
-				}
-				defer dcm.Close()
-
-				if err != nil {
-					t.Errorf("Unable to stat %s. Error: %v", f.Name(), err)
-				}
+				dcm := readTestdataFile(t, f.Name())
 				parse_eof_dataset, err := ParseUntilEOF(dcm, nil)
 				if err != nil {
 					t.Errorf("dicom.ParseUntilEOF(%s) unexpected error: %v", f.Name(), err)
 				}
 
 				// Read dataset with Parse
-				dcm2, err := os.Open("./testdata/" + f.Name())
-				if err != nil {
-					t.Errorf("Unable to open %s. Error: %v", f.Name(), err)
-				}
-				defer dcm2.Close()
+				dcm2 := readTestdataFile(t, f.Name())
 				info, err := dcm2.Stat()
 				if err != nil {
 					t.Errorf("Unable to stat %s. Error: %v", f.Name(), err)
@@ -54,10 +42,7 @@ func TestParseUntilEOFConformsToParse(t *testing.T) {
 				}
 
 				// Ensure dataset read from ParseUntilEOF and Parse are the same.
-				cmpOpts := []cmp.Option{
-					cmp.AllowUnexported(allValues...),
-				}
-				if diff := cmp.Diff(parse_dataset, parse_eof_dataset, cmpOpts...); diff != "" {
+				if diff := cmp.Diff(parse_dataset, parse_eof_dataset, cmp.AllowUnexported(allValues...)); diff != "" {
 					t.Errorf("dicom.Parse and dicom.ParseUntilEOF do not result in the same dataset. diff: %v", diff)
 				}
 			})
@@ -65,3 +50,11 @@ func TestParseUntilEOFConformsToParse(t *testing.T) {
 	}
 }
 
+func readTestdataFile(t *testing.T, name string) *os.File {
+	dcm, err := os.Open("./testdata/" + name)
+	if err != nil {
+		t.Errorf("Unable to open %s. Error: %v", name, err)
+	}
+	t.Cleanup(func() { dcm.Close() })
+	return dcm
+}

--- a/parse_internal_test.go
+++ b/parse_internal_test.go
@@ -1,0 +1,67 @@
+package dicom
+
+import (
+	"io/ioutil"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+// TestParseUntilEOFConformsToParse runs both the dicom.ParseUntilEOF and the dicom.Parse APIs against each
+// testdata file and ensures the outputs are the same.
+// This test lives in parse_internal_test.go because this test cannot live in the dicom_test package, due
+// to some dependencies on internal valuesets for diffing.
+func TestParseUntilEOFConformsToParse(t *testing.T) {
+	files, err := ioutil.ReadDir("./testdata")
+	if err != nil {
+		t.Fatalf("unable to read testdata/: %v", err)
+	}
+	for _, f := range files {
+		f := f
+		if !f.IsDir() && strings.HasSuffix(f.Name(), ".dcm") {
+			t.Run(f.Name(), func(t *testing.T) {
+				t.Parallel()
+				// Read dataset with ParseUntilEOF
+				dcm, err := os.Open("./testdata/" + f.Name())
+				if err != nil {
+					t.Errorf("Unable to open %s. Error: %v", f.Name(), err)
+				}
+				defer dcm.Close()
+
+				if err != nil {
+					t.Errorf("Unable to stat %s. Error: %v", f.Name(), err)
+				}
+				parse_eof_dataset, err := ParseUntilEOF(dcm, nil)
+				if err != nil {
+					t.Errorf("dicom.ParseUntilEOF(%s) unexpected error: %v", f.Name(), err)
+				}
+
+				// Read dataset with Parse
+				dcm2, err := os.Open("./testdata/" + f.Name())
+				if err != nil {
+					t.Errorf("Unable to open %s. Error: %v", f.Name(), err)
+				}
+				defer dcm2.Close()
+				info, err := dcm2.Stat()
+				if err != nil {
+					t.Errorf("Unable to stat %s. Error: %v", f.Name(), err)
+				}
+				parse_dataset, err := Parse(dcm2, info.Size(), nil)
+				if err != nil {
+					t.Errorf("dicom.Parse(%s) unexpected error: %v", f.Name(), err)
+				}
+
+				// Ensure dataset read from ParseUntilEOF and Parse are the same.
+				cmpOpts := []cmp.Option{
+					cmp.AllowUnexported(allValues...),
+				}
+				if diff := cmp.Diff(parse_dataset, parse_eof_dataset, cmpOpts...); diff != "" {
+					t.Errorf("dicom.Parse and dicom.ParseUntilEOF do not result in the same dataset. diff: %v", diff)
+				}
+			})
+		}
+	}
+}
+


### PR DESCRIPTION
This PR introduces a test function that runs both `dicom.Parse` and `dicom.ParseUntilEOF` against `testdata/` and ensures they produce the same dataset. 

The test does take a while to run (50-60s), because the diffing on `testdata/4.dcm` takes a long while. However, I feel it's good to have this conformance check in there, and perhaps we can either exclude (or special case) `4.dcm` in the future or find a way to speed the diffing up.

When running in parallel on GitHub actions runners though, the whole test suite still takes [less than 2mins total to run](https://github.com/suyashkumar/dicom/actions/runs/4889797002/jobs/8728628132), which isn't bad. It's more for local development and iteration that the greatly increased test time is a bit annoying. 